### PR TITLE
How old are my dibs?

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ in the report:
 terminus site:dibs:report your-site '^((?!^(dev|test|live)$).)*$'
 ```
 
+You can also supply in seconds a filter to only see a list of environments that have been dibs'd for a certain amount of time:
+
+```sh
+terminus site:dibs:report tableau '^((?!^(dev|test|live)$).)*$' 1800
+```
+
+
 ## Use-cases
 
 This plugin assumes that you have persistent or semi-persistent environments

--- a/src/Commands/DibsCommand.php
+++ b/src/Commands/DibsCommand.php
@@ -174,7 +174,7 @@ class DibsCommand extends TerminusCommand implements SiteAwareInterface {
    * @param string $filter An optional regex pattern used to filter the pool of
    *   environments for which you wish to view the report.
    * 
-   * @param integer $duration An optional threshold for duration that an environment has been dibs'd in seconds.
+   * @param integer $duration An optional time threshold (seconds) for duration that an environment has been dibs'd.
    * 
    * @return RowsOfFields
    *


### PR DESCRIPTION
Add the ability to retrieve a list of filtered environments that have been dibs'd for a certain amount of time to envDibsReport. Defaults to reporting all environment statuses if no threshold was given. 

`terminus site:dibs:report <site> [<env-name-pattern>] [<seconds>]`